### PR TITLE
Add missing CLIP package to `env.yml`

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -32,3 +32,4 @@ dependencies:
     - dpu_utils
     - more_itertools
     - git+https://github.com/ml-jku/mhn-react.git#egg=mhnreact
+    - git+https://github.com/openai/CLIP.git#egg=clip


### PR DESCRIPTION
This PR addresses an issue where the code fails to run after installation using the provided `conda` environment file (`env.yml`). Specifically, the error encountered is:

`ModuleNotFoundError: No module named 'clip'`

This error occurs because the `clip` package is not listed in the `pip` dependencies of the `env.yml` file. To resolve this issue, I've added the missing `clip` package to the `pip` dependencies of the `env.yml` file. The added `clip` package is the same as in the `setup.py` script for installation.