### PR TITLE
Use rdkit instead of rdkit-pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         scipy
         pandas
         nltk
-        rdkit-pypi
+        rdkit
         transformers
         matplotlib
         torch


### PR DESCRIPTION
Please update the dependencies in setup.py to use rdkit-pypi instead of rdkit.